### PR TITLE
Add `Add the app to a channel` instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Visit `https://api.slack.com/apps/<YOUR_APP_ID>/install-on-team` and then instal
 
 ![screenshot](./docs/assets/screenshot-slack-install-app.png)
 
+4. Add the app to a channel
+
+Open a Slack channel and add the app.
+
 </details>
 
 ## Inputs


### PR DESCRIPTION
## What this PR does / Why we need it

Unless you add the app to a channel, you'll get a `not_in_channel` error.

## Which issue(s) this PR fixes

None
