### PR TITLE
Add message input to custom payload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           channel: develop
+          message: 'This text is for notifications.'
           custom_payload: |
             {
               "blocks": [


### PR DESCRIPTION
## What this PR does / Why we need it

Usually, Slack uses the first text field of blocks for its notification text, but this action requires `message` input instead.

## Which issue(s) this PR fixes

None
