### PR TITLE
Change release target branch from master to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
## What this PR does / Why we need it

The default branch of this repository has changed to main, but the release workflow has not reflected the change.

## Which issue(s) this PR fixes

None.
